### PR TITLE
Summary page formatting: Change rowspan to 0 to apply header to all rows in section

### DIFF
--- a/client/src/components/App/SummaryPage.js
+++ b/client/src/components/App/SummaryPage.js
@@ -107,8 +107,8 @@ const SummaryPage = () => {
             return (
               <tbody key={client.id}>
               <tr key={client.id}>
-                <th rowSpan="5">{client.name}</th>
-                <th rowSpan="5">{user}</th>
+                <th rowSpan="0">{client.name}</th>
+                <th rowSpan="0">{user}</th>
               </tr>
               {bucketRender}
               </tbody>


### PR DESCRIPTION
Hi @guillogo , we have another small bugfix here. Having the rowspan = 5 meant the formatting of the summary page got screwed up when it got bigger than 5 rows.

Hope it is easy for you to deploy, thanks!